### PR TITLE
Removed 52it:Bip44ForJava dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,12 +19,6 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
     implementation 'org.slf4j:slf4j-simple:1.6.1'
-    implementation('org.bouncycastle:bcprov-jdk15on') {
-        version {
-            strictly '1.63'
-        }
-    }
-    implementation 'party.52it:Bip44ForJava:1.0.0'
     implementation 'org.bitcoinj:bitcoinj-core:0.15.10'
     implementation 'org.web3j:core:4.8.4'
     implementation 'com.madgag.spongycastle:core:1.58.0.0'

--- a/src/main/java/com/antsmc2/common/CommonUtil.java
+++ b/src/main/java/com/antsmc2/common/CommonUtil.java
@@ -1,21 +1,21 @@
 package com.antsmc2.common;
 
-import party.loveit.bip44forjava.utils.Bip44Utils;
-import party.loveit.bip44forjava.utils.EnglishWords;
-import party.loveit.bip44forjava.utils.MnemonicCode;
-
+import org.web3j.crypto.MnemonicUtils;
+import java.util.Arrays;
 import java.util.List;
 
-import static party.loveit.bip44forjava.utils.EnglishWords.*;
 
 public class CommonUtil {
 
     public static List<String> generateMnemonicsPhrase() throws Exception {
-        return Bip44Utils.generateMnemonicWords();
+        byte[] initialEntropy = new byte[16];
+        SecureRandomUtils.secureRandom().nextBytes(initialEntropy);
+        String mnemonic = MnemonicUtils.generateMnemonic(initialEntropy);
+        return Arrays.asList(mnemonic.split(" "));
     }
 
     public static List<String> getAllMnemonicsWords() {
-        return MnemonicCode.INSTANCE.getWordList();
+        return MnemonicUtils.getWords();
     }
 
     public static byte[] getSeed(List<String> words) {
@@ -23,8 +23,6 @@ public class CommonUtil {
     }
 
     public static byte[] getSeed(List<String> words, String paraphrase) {
-        if(paraphrase == null)
-            paraphrase = "";
-        return MnemonicCode.toSeed(words, paraphrase);
+        return MnemonicUtils.generateSeed(String.join(" ", words), paraphrase);
     }
 }

--- a/src/main/java/com/antsmc2/common/CryptoWallet.java
+++ b/src/main/java/com/antsmc2/common/CryptoWallet.java
@@ -1,6 +1,7 @@
 package com.antsmc2.common;
 
-import party.loveit.bip44forjava.utils.Bip44Utils;
+import org.web3j.crypto.Bip32ECKeyPair;
+import static org.web3j.crypto.Bip32ECKeyPair.HARDENED_BIT;
 import java.math.BigInteger;
 import java.util.List;
 
@@ -16,9 +17,12 @@ public interface CryptoWallet {
      */
     default BigInteger getDerivedPrivateKey(Integer addressId) {
         Integer coinType = this.getCoinType();
-        String keyPath = String.format("m/44'/%s'/0'/0/%s", coinType, addressId);
         List<String> words = getMnemonicPhrase();
-        return Bip44Utils.getPathPrivateKey(words, keyPath);
+        final int[] path = {44 | HARDENED_BIT, coinType | HARDENED_BIT, 0 | HARDENED_BIT, 0, addressId};
+        byte[] seed = CommonUtil.getSeed(words);
+        Bip32ECKeyPair masterKey = Bip32ECKeyPair.generateKeyPair(seed);
+        Bip32ECKeyPair keyPair = Bip32ECKeyPair.deriveKeyPair(masterKey, path);
+        return keyPair.getPrivateKey();
     }
 
     /**

--- a/src/main/java/com/antsmc2/common/SecureRandomUtils.java
+++ b/src/main/java/com/antsmc2/common/SecureRandomUtils.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.antsmc2.common;
+
+// This file is taken from web3j implementation:
+// https://github.com/web3j/web3j/blob/49fe2c4e2d9d325ec465879736d6c384f41a4115/crypto/src/main/java/org/web3j/crypto/SecureRandomUtils.java#L23
+import org.web3j.crypto.LinuxSecureRandom;
+
+import java.security.SecureRandom;
+
+/**
+ * Utility class for working with SecureRandom implementation.
+ *
+ * <p>This is to address issues with SecureRandom on Android. For more information, refer to the
+ * following <a href="https://github.com/web3j/web3j/issues/146">issue</a>.
+ */
+final class SecureRandomUtils {
+
+    private static final SecureRandom SECURE_RANDOM;
+
+    static {
+        if (isAndroidRuntime()) {
+            new LinuxSecureRandom();
+        }
+        SECURE_RANDOM = new SecureRandom();
+    }
+
+    static SecureRandom secureRandom() {
+        return SECURE_RANDOM;
+    }
+
+    // Taken from BitcoinJ implementation
+    // https://github.com/bitcoinj/bitcoinj/blob/3cb1f6c6c589f84fe6e1fb56bf26d94cccc85429/core/src/main/java/org/bitcoinj/core/Utils.java#L573
+    private static int isAndroid = -1;
+
+    static boolean isAndroidRuntime() {
+        if (isAndroid == -1) {
+            final String runtime = System.getProperty("java.runtime.name");
+            isAndroid = (runtime != null && runtime.equals("Android Runtime")) ? 1 : 0;
+        }
+        return isAndroid == 1;
+    }
+
+    private SecureRandomUtils() {}
+}

--- a/src/main/java/com/antsmc2/wallet/BitcoinWallet.java
+++ b/src/main/java/com/antsmc2/wallet/BitcoinWallet.java
@@ -10,7 +10,6 @@ import org.bitcoinj.script.Script;
 import java.math.BigInteger;
 import java.util.List;
 
-
 public class BitcoinWallet implements CryptoWallet {
     private Integer coinType;
     private final List<String> mnemonicPhrase;

--- a/src/main/java/com/antsmc2/wallet/EthereumWallet.java
+++ b/src/main/java/com/antsmc2/wallet/EthereumWallet.java
@@ -4,7 +4,6 @@ import com.antsmc2.common.CryptoWallet;
 import org.web3j.crypto.ECKeyPair;
 import org.web3j.crypto.Keys;
 import org.web3j.utils.Numeric;
-
 import java.math.BigInteger;
 import java.util.List;
 

--- a/src/main/java/com/antsmc2/wallet/TronWallet.java
+++ b/src/main/java/com/antsmc2/wallet/TronWallet.java
@@ -2,11 +2,6 @@ package com.antsmc2.wallet;
 
 import com.antsmc2.common.CryptoWallet;
 import com.github.ki5fpl.tronj.key.KeyPair;
-import org.web3j.crypto.ECKeyPair;
-import org.web3j.crypto.Keys;
-import org.web3j.utils.Numeric;
-
-import java.math.BigInteger;
 import java.util.List;
 
 public class TronWallet implements CryptoWallet {

--- a/src/test/java/com/antsmc2/common/CommonUtilTest.java
+++ b/src/test/java/com/antsmc2/common/CommonUtilTest.java
@@ -2,8 +2,6 @@ package com.antsmc2.common;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import party.loveit.bip44forjava.utils.Bip44Utils;
-
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;

--- a/src/test/java/com/antsmc2/common/CryptoWalletTest.java
+++ b/src/test/java/com/antsmc2/common/CryptoWalletTest.java
@@ -2,7 +2,6 @@ package com.antsmc2.common;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;

--- a/src/test/java/com/antsmc2/wallet/BitcoinWalletTest.java
+++ b/src/test/java/com/antsmc2/wallet/BitcoinWalletTest.java
@@ -2,7 +2,6 @@ package com.antsmc2.wallet;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
 import java.util.Arrays;
 import java.util.List;
 

--- a/src/test/java/com/antsmc2/wallet/EthereumWalletTest.java
+++ b/src/test/java/com/antsmc2/wallet/EthereumWalletTest.java
@@ -2,7 +2,6 @@ package com.antsmc2.wallet;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
 import java.util.Arrays;
 import java.util.List;
 

--- a/src/test/java/com/antsmc2/wallet/TronWalletTest.java
+++ b/src/test/java/com/antsmc2/wallet/TronWalletTest.java
@@ -2,7 +2,6 @@ package com.antsmc2.wallet;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
 import java.util.Arrays;
 import java.util.List;
 


### PR DESCRIPTION
All functionality used from `party.52it:Bip44ForJava:1.0.0` are derivable from web3j and bitcoinj libraries and they are better maintained. This change essentially removes that dependency and generates the mnemonic code and master private keys mostly using [web3j](https://github.com/web3j/web3j).